### PR TITLE
Block Tracking Code Manager until consent

### DIFF
--- a/inc/Base/TrackingCodeManagerBlocker.php
+++ b/inc/Base/TrackingCodeManagerBlocker.php
@@ -1,0 +1,31 @@
+<?php
+
+class TrackingCodeManagerBlocker
+{
+    public function register()
+    {
+        add_action('init', [$this, 'maybe_block'], 0);
+    }
+
+    public function maybe_block()
+    {
+        if (is_admin()) {
+            return;
+        }
+
+        // Get consent cookie
+        $prefs = isset($_COOKIE['user_accepted_cookies']) ? json_decode(stripslashes($_COOKIE['user_accepted_cookies']), true) : [];
+
+        $marketing = $prefs['marketing'] ?? false;
+        $statistics = $prefs['statistics'] ?? false;
+
+        if (!$marketing && !$statistics) {
+            if (function_exists('tcmp_head')) {
+                $priority = get_option('TCM_HookPriority', defined('TCMP_HOOK_PRIORITY_DEFAULT') ? TCMP_HOOK_PRIORITY_DEFAULT : 10);
+                remove_filter('wp_head', 'tcmp_head', $priority);
+                remove_action('wp_body_open', 'tcmp_body', $priority);
+                remove_action('wp_footer', 'tcmp_footer', $priority);
+            }
+        }
+    }
+}

--- a/inc/LionCookieInit.php
+++ b/inc/LionCookieInit.php
@@ -7,6 +7,7 @@ spl_autoload_register(function ($class_name) {
         'CookieActivate' => 'Base/CookieActivate.php',
         'CookieDeactivate' => 'Base/CookieDeactivate.php',
         'CookieEnqueue' => 'Base/CookieEnqueue.php',
+        'TrackingCodeManagerBlocker' => 'Base/TrackingCodeManagerBlocker.php',
         
         'AdminMenu' => 'Admin/AdminMenu.php',
         'CookieSettings' => 'Admin/CookieSettings.php',
@@ -38,6 +39,7 @@ final class LionCookieInit {
             CookieDescriptions::class,
             CookieStatistics::class,
             CookieChangeDecision::class,
+            TrackingCodeManagerBlocker::class,
         ];
     }
 


### PR DESCRIPTION
## Summary
- Prevent Tracking Code Manager from setting cookies before consent
- Register blocker class in plugin initialization

## Testing
- `php -l inc/Base/TrackingCodeManagerBlocker.php`
- `php -l inc/LionCookieInit.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac3353d5fc8325890cf342a242904c